### PR TITLE
Decreases mime version to fix problems in other apps

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,5 +14,5 @@ dependencies:
   device_info_plus: ^11.1.1
   package_info_plus: ^8.1.1
   connectivity_plus: ^6.1.0
-  mime: ^2.0.0
+  mime: ^1.0.0
   battery_plus: ^6.2.0


### PR DESCRIPTION
Fixes this:

```
Resolving dependencies...
The current Dart SDK version is 3.4.4.
Because no versions of inventiv_critic_flutter match >0.4.0 <0.5.0 and inventiv_critic_flutter 0.4.0 depends on mime ^2.0.0, inventiv_critic_flutter ^0.4.0 requires mime ^2.0.0.
And because build_runner >=2.0.0 <2.4.12 depends on mime ^1.0.0 and build_runner >=2.4.12 requires SDK version >=3.5.0-259.0.dev <4.0.0, inventiv_critic_flutter ^0.4.0 is incompatible with build_runner >=2.0.0.
So, because flutter_app_base depends on both inventiv_critic_flutter ^0.4.0 and build_runner ^2.4.6, version solving failed.
You can try the following suggestion to make the pubspec resolve:
* Try using the Flutter SDK version: 3.29.0. 
Error: Process completed with exit code 1.
```