### PR TITLE
Bump plus packages and Android toolchain for v0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ example/.flutter-plugins-dependencies
 .fvm/
 .flutter-plugins-dependencies
 .idea/
+**/ephemeral/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.0
+
+Bump plus packages to latest major versions (connectivity_plus 7.x, device_info_plus 12.x, package_info_plus 9.x, battery_plus 7.x).
+Update Android toolchain (AGP 8.12.1, Gradle 8.13, Kotlin 2.2.0).
+Tighten SDK constraint to >=3.7.0.
+
 ## 0.4.0
 
 Updated dependencies and gradle version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## 0.5.0
 
-Bump plus packages to latest major versions (connectivity_plus 7.x, device_info_plus 12.x, package_info_plus 9.x, battery_plus 7.x).
+**BREAKING:** Minimum Dart SDK raised from 2.12.0 to 3.7.0. This is required by the
+updated plus packages (connectivity_plus 7.x, device_info_plus 12.x, package_info_plus 9.x,
+battery_plus 7.x), which all require Dart >=3.7.0.
+
 Update Android toolchain (AGP 8.12.1, Gradle 8.13, Kotlin 2.2.0).
-Tighten SDK constraint to >=3.7.0.
 
 ## 0.4.0
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ if (flutterVersionName == null) {
 android {
     compileSdkVersion 34
 
-    lintOptions {
+    lint {
         disable 'InvalidPackage'
     }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Dec 05 12:52:06 CST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.1.0' apply false
-    id "org.jetbrains.kotlin.android" version "1.8.10" apply false
+    id "com.android.application" version '8.12.1' apply false
+    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }
 
 include ":app"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,18 @@
 name: inventiv_critic_flutter
 description: A flutter plugin for Critic integration.
-version: 0.4.0
+version: 0.5.0
 homepage: https://www.twinsunsolutions.com
 repository: https://github.com/twinsunllc/critic_flutter
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
   http: ^1.2.2
-  device_info_plus: ^11.1.1
-  package_info_plus: ^8.1.1
-  connectivity_plus: ^6.1.0
+  device_info_plus: ^12.3.0
+  package_info_plus: ^9.0.0
+  connectivity_plus: ^7.0.0
   mime: ^1.0.0
-  battery_plus: ^6.2.0
+  battery_plus: ^7.0.0


### PR DESCRIPTION
## Summary
- **BREAKING:** Minimum Dart SDK raised from 2.12.0 to 3.7.0 (required by the updated plus packages below)
- Upgrade plus packages to latest major versions: connectivity_plus 7.x, device_info_plus 12.x, package_info_plus 9.x, battery_plus 7.x
- Update Android toolchain: AGP 8.12.1, Gradle 8.13, Kotlin 2.2.0
- Add `**/ephemeral/` to .gitignore
- Version bump to 0.5.0

## Test plan
- [ ] Run `flutter pub get` and verify dependency resolution
- [ ] Build and run example app on Android
- [ ] Build and run example app on iOS
- [ ] Verify Critic reporting functionality works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)