### PR TITLE
feat: add v3 GET endpoints for bug reports and devices

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -6,6 +6,8 @@ import 'package:battery_plus/battery_plus.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:http/http.dart' as http;
 import 'package:inventiv_critic_flutter/modal/bug_report.dart';
+import 'package:inventiv_critic_flutter/modal/device.dart';
+import 'package:inventiv_critic_flutter/modal/paginated_response.dart';
 import 'package:inventiv_critic_flutter/modal/ping_request_modal.dart';
 import 'package:inventiv_critic_flutter/modal/ping_response.dart';
 import 'package:inventiv_critic_flutter/modal/report_request_modal.dart';
@@ -126,5 +128,67 @@ class Api {
     });
 
     return completer.future;
+  }
+
+  static Future<PaginatedResponse<BugReport>> listBugReports(
+    String appApiToken, {
+    bool? archived,
+    String? deviceId,
+    String? since,
+  }) async {
+    final queryParams = <String, String>{'app_api_token': appApiToken};
+    if (archived == true) queryParams['archived'] = 'true';
+    if (deviceId != null) queryParams['device_id'] = deviceId;
+    if (since != null) queryParams['since'] = since;
+
+    final uri = Uri.parse(
+      '$_apiUrl/bug_reports',
+    ).replace(queryParameters: queryParams);
+    final response = await http.get(uri);
+    if (response.statusCode == 200) {
+      final data = json.decode(response.body) as Map<String, dynamic>;
+      return PaginatedResponse.fromJson(
+        data,
+        'bug_reports',
+        BugReport.fromJson,
+      );
+    } else {
+      throw Exception(
+        'Response code: ${response.statusCode}, ${response.body}',
+      );
+    }
+  }
+
+  static Future<BugReport> getBugReport(String appApiToken, String id) async {
+    final uri = Uri.parse(
+      '$_apiUrl/bug_reports/${Uri.encodeComponent(id)}',
+    ).replace(queryParameters: {'app_api_token': appApiToken});
+    final response = await http.get(uri);
+    if (response.statusCode == 200) {
+      return BugReport.fromJson(
+        json.decode(response.body) as Map<String, dynamic>,
+      );
+    } else {
+      throw Exception(
+        'Response code: ${response.statusCode}, ${response.body}',
+      );
+    }
+  }
+
+  static Future<PaginatedResponse<Device>> listDevices(
+    String appApiToken,
+  ) async {
+    final uri = Uri.parse(
+      '$_apiUrl/devices',
+    ).replace(queryParameters: {'app_api_token': appApiToken});
+    final response = await http.get(uri);
+    if (response.statusCode == 200) {
+      final data = json.decode(response.body) as Map<String, dynamic>;
+      return PaginatedResponse.fromJson(data, 'devices', Device.fromJson);
+    } else {
+      throw Exception(
+        'Response code: ${response.statusCode}, ${response.body}',
+      );
+    }
   }
 }

--- a/lib/critic.dart
+++ b/lib/critic.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:inventiv_critic_flutter/api.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:inventiv_critic_flutter/api.dart';
 import 'package:inventiv_critic_flutter/modal/app.dart';
 import 'package:inventiv_critic_flutter/modal/bug_report.dart';
 import 'package:inventiv_critic_flutter/modal/device.dart';
+import 'package:inventiv_critic_flutter/modal/paginated_response.dart';
 import 'package:inventiv_critic_flutter/modal/ping_request_modal.dart';
 import 'package:inventiv_critic_flutter/modal/ping_response.dart';
 import 'package:inventiv_critic_flutter/modal/report_request_modal.dart';
@@ -102,5 +103,27 @@ class Critic {
       report: report,
     );
     return await Api.submitReport(requestData);
+  }
+
+  static Future<PaginatedResponse<BugReport>> listBugReports(
+    String appApiToken, {
+    bool? archived,
+    String? deviceId,
+    String? since,
+  }) {
+    return Api.listBugReports(
+      appApiToken,
+      archived: archived,
+      deviceId: deviceId,
+      since: since,
+    );
+  }
+
+  static Future<BugReport> getBugReport(String appApiToken, String id) {
+    return Api.getBugReport(appApiToken, id);
+  }
+
+  static Future<PaginatedResponse<Device>> listDevices(String appApiToken) {
+    return Api.listDevices(appApiToken);
   }
 }

--- a/lib/modal/device.dart
+++ b/lib/modal/device.dart
@@ -1,28 +1,54 @@
+import 'package:inventiv_critic_flutter/modal/device_status.dart';
+import 'package:inventiv_critic_flutter/modal/ping_response.dart';
+
 class Device {
-  String? identifier,
+  String? id,
+      identifier,
       manufacturer,
       model,
       networkCarrier,
       platform,
-      platformVersion;
+      platformVersion,
+      createdAt,
+      updatedAt;
+  List<AppInstall>? appInstall;
+  List<DeviceStatus>? deviceStatus;
 
   Device({
+    this.id,
     this.identifier,
     this.manufacturer,
     this.model,
     this.networkCarrier,
     this.platform,
     this.platformVersion,
+    this.createdAt,
+    this.updatedAt,
+    this.appInstall,
+    this.deviceStatus,
   });
 
   factory Device.fromJson(Map<String, dynamic> json) {
     return Device(
+      id: json['id']?.toString(),
       identifier: json['identifier'],
       manufacturer: json['manufacturer'],
       model: json['model'],
       networkCarrier: json['network_carrier'],
       platform: json['platform'],
       platformVersion: json['platform_version'],
+      createdAt: json['created_at'],
+      updatedAt: json['updated_at'],
+      appInstall:
+          json['app_install'] != null
+              ? (json['app_install'] as List<dynamic>)
+                  .map(
+                    (item) =>
+                        AppInstall.fromNestedJson(item as Map<String, dynamic>),
+                  )
+                  .toList()
+              : null,
+      deviceStatus: DeviceStatus.fromList(json['device_status']),
     );
   }
 

--- a/lib/modal/device_status.dart
+++ b/lib/modal/device_status.dart
@@ -1,0 +1,77 @@
+class DeviceStatus {
+  String? id;
+  bool? batteryCharging;
+  num? batteryLevel;
+  String? batteryHealth;
+  num? diskFree;
+  num? diskPlatform;
+  num? diskTotal;
+  num? diskUsable;
+  num? memoryActive;
+  num? memoryFree;
+  num? memoryInactive;
+  num? memoryPurgable;
+  num? memoryTotal;
+  num? memoryWired;
+  Map<String, dynamic>? metadata;
+  bool? networkCellConnected;
+  int? networkCellSignalBars;
+  bool? networkWifiConnected;
+  int? networkWifiSignalBars;
+
+  DeviceStatus({
+    this.id,
+    this.batteryCharging,
+    this.batteryLevel,
+    this.batteryHealth,
+    this.diskFree,
+    this.diskPlatform,
+    this.diskTotal,
+    this.diskUsable,
+    this.memoryActive,
+    this.memoryFree,
+    this.memoryInactive,
+    this.memoryPurgable,
+    this.memoryTotal,
+    this.memoryWired,
+    this.metadata,
+    this.networkCellConnected,
+    this.networkCellSignalBars,
+    this.networkWifiConnected,
+    this.networkWifiSignalBars,
+  });
+
+  factory DeviceStatus.fromJson(Map<String, dynamic> json) {
+    return DeviceStatus(
+      id: json['id']?.toString(),
+      batteryCharging: json['battery_charging'],
+      batteryLevel: json['battery_level'],
+      batteryHealth: json['battery_health'],
+      diskFree: json['disk_free'],
+      diskPlatform: json['disk_platform'],
+      diskTotal: json['disk_total'],
+      diskUsable: json['disk_usable'],
+      memoryActive: json['memory_active'],
+      memoryFree: json['memory_free'],
+      memoryInactive: json['memory_inactive'],
+      memoryPurgable: json['memory_purgable'],
+      memoryTotal: json['memory_total'],
+      memoryWired: json['memory_wired'],
+      metadata:
+          json['metadata'] != null
+              ? Map<String, dynamic>.from(json['metadata'])
+              : null,
+      networkCellConnected: json['network_cell_connected'],
+      networkCellSignalBars: json['network_cell_signal_bars'],
+      networkWifiConnected: json['network_wifi_connected'],
+      networkWifiSignalBars: json['network_wifi_signal_bars'],
+    );
+  }
+
+  static List<DeviceStatus> fromList(List<dynamic>? items) {
+    if (items == null) return <DeviceStatus>[];
+    return items
+        .map((item) => DeviceStatus.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/lib/modal/paginated_response.dart
+++ b/lib/modal/paginated_response.dart
@@ -1,0 +1,29 @@
+class PaginatedResponse<T> {
+  final int count;
+  final int currentPage;
+  final int totalPages;
+  final List<T> items;
+
+  PaginatedResponse({
+    required this.count,
+    required this.currentPage,
+    required this.totalPages,
+    required this.items,
+  });
+
+  factory PaginatedResponse.fromJson(
+    Map<String, dynamic> json,
+    String itemsKey,
+    T Function(Map<String, dynamic>) fromJsonT,
+  ) {
+    return PaginatedResponse<T>(
+      count: json['count'] as int,
+      currentPage: json['current_page'] as int,
+      totalPages: json['total_pages'] as int,
+      items:
+          (json[itemsKey] as List<dynamic>)
+              .map((item) => fromJsonT(item as Map<String, dynamic>))
+              .toList(),
+    );
+  }
+}

--- a/lib/modal/ping_response.dart
+++ b/lib/modal/ping_response.dart
@@ -1,11 +1,34 @@
+import 'package:inventiv_critic_flutter/modal/bug_report.dart';
+
 class AppInstall {
   String id;
+  String? createdAt;
+  String? updatedAt;
+  AppVersion? appVersion;
 
-  AppInstall({required this.id});
+  AppInstall({
+    required this.id,
+    this.createdAt,
+    this.updatedAt,
+    this.appVersion,
+  });
 
   factory AppInstall.fromJson(Map<String, dynamic> jsonBody) {
     Map<String, dynamic> json = jsonBody['app_install'];
     return AppInstall(id: json['id'].toString());
+  }
+
+  /// Parse a nested app_install object (e.g. within a device response).
+  factory AppInstall.fromNestedJson(Map<String, dynamic> json) {
+    return AppInstall(
+      id: json['id'].toString(),
+      createdAt: json['created_at'],
+      updatedAt: json['updated_at'],
+      appVersion:
+          json['app_version'] != null
+              ? AppVersion.fromJson(json['app_version'])
+              : null,
+    );
   }
 
   Map<String, dynamic> toJson() => <String, dynamic>{'id': id};

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:inventiv_critic_flutter/modal/ping_response.dart';
 import 'package:inventiv_critic_flutter/modal/bug_report.dart';
-import 'package:inventiv_critic_flutter/modal/app.dart';
 import 'package:inventiv_critic_flutter/modal/device.dart';
+import 'package:inventiv_critic_flutter/modal/device_status.dart';
+import 'package:inventiv_critic_flutter/modal/paginated_response.dart';
+import 'package:inventiv_critic_flutter/modal/ping_response.dart';
+import 'package:inventiv_critic_flutter/modal/app.dart';
 
 void main() {
   group('AppInstall', () {
@@ -226,6 +228,286 @@ void main() {
       expect(app.platform, 'iOS');
       expect(app.version.code, '10');
       expect(app.version.name, '2.1.0');
+    });
+  });
+
+  group('DeviceStatus', () {
+    test('fromJson parses all fields', () {
+      final json = {
+        'id': 'ds-uuid-123',
+        'battery_charging': true,
+        'battery_level': 85,
+        'battery_health': 'Good',
+        'disk_free': 1073741824,
+        'disk_platform': 2147483648,
+        'disk_total': 137438953472,
+        'disk_usable': 128849018880,
+        'memory_active': 1073741824,
+        'memory_free': 536870912,
+        'memory_inactive': 536870912,
+        'memory_purgable': 2147483648,
+        'memory_total': 8589934592,
+        'memory_wired': 134217728,
+        'metadata': {'latitude': 31.98, 'longitude': -23.56},
+        'network_cell_connected': true,
+        'network_cell_signal_bars': 3,
+        'network_wifi_connected': true,
+        'network_wifi_signal_bars': 4,
+      };
+
+      final status = DeviceStatus.fromJson(json);
+      expect(status.id, 'ds-uuid-123');
+      expect(status.batteryCharging, true);
+      expect(status.batteryLevel, 85);
+      expect(status.batteryHealth, 'Good');
+      expect(status.diskFree, 1073741824);
+      expect(status.diskTotal, 137438953472);
+      expect(status.memoryTotal, 8589934592);
+      expect(status.metadata, {'latitude': 31.98, 'longitude': -23.56});
+      expect(status.networkCellConnected, true);
+      expect(status.networkCellSignalBars, 3);
+      expect(status.networkWifiConnected, true);
+      expect(status.networkWifiSignalBars, 4);
+    });
+
+    test('fromJson handles all null fields', () {
+      final json = <String, dynamic>{
+        'id': null,
+        'battery_charging': null,
+        'battery_level': null,
+        'battery_health': null,
+        'disk_free': null,
+        'disk_platform': null,
+        'disk_total': null,
+        'disk_usable': null,
+        'memory_active': null,
+        'memory_free': null,
+        'memory_inactive': null,
+        'memory_purgable': null,
+        'memory_total': null,
+        'memory_wired': null,
+        'metadata': null,
+        'network_cell_connected': null,
+        'network_cell_signal_bars': null,
+        'network_wifi_connected': null,
+        'network_wifi_signal_bars': null,
+      };
+
+      final status = DeviceStatus.fromJson(json);
+      expect(status.id, isNull);
+      expect(status.batteryCharging, isNull);
+      expect(status.metadata, isNull);
+    });
+
+    test('fromList parses list of statuses', () {
+      final items = [
+        {'id': 'ds-1', 'battery_level': 50},
+        {'id': 'ds-2', 'battery_level': 75},
+      ];
+      final statuses = DeviceStatus.fromList(items);
+      expect(statuses.length, 2);
+      expect(statuses[0].id, 'ds-1');
+      expect(statuses[1].batteryLevel, 75);
+    });
+
+    test('fromList handles null input', () {
+      final statuses = DeviceStatus.fromList(null);
+      expect(statuses, isEmpty);
+    });
+  });
+
+  group('PaginatedResponse', () {
+    test('fromJson parses bug_reports response', () {
+      final json = {
+        'count': 42,
+        'current_page': 1,
+        'total_pages': 5,
+        'bug_reports': [
+          {
+            'id': 'bug-1',
+            'description': 'First bug',
+            'steps_to_reproduce': null,
+            'user_identifier': null,
+            'created_at': '2026-01-01T00:00:00Z',
+            'updated_at': '2026-01-02T00:00:00Z',
+            'attachments': null,
+          },
+          {
+            'id': 'bug-2',
+            'description': 'Second bug',
+            'steps_to_reproduce': null,
+            'user_identifier': null,
+            'created_at': null,
+            'updated_at': null,
+            'attachments': null,
+          },
+        ],
+      };
+
+      final response = PaginatedResponse.fromJson(
+        json,
+        'bug_reports',
+        BugReport.fromJson,
+      );
+      expect(response.count, 42);
+      expect(response.currentPage, 1);
+      expect(response.totalPages, 5);
+      expect(response.items.length, 2);
+      expect(response.items[0].id, 'bug-1');
+      expect(response.items[1].description, 'Second bug');
+    });
+
+    test('fromJson parses devices response', () {
+      final json = {
+        'count': 2,
+        'current_page': 1,
+        'total_pages': 1,
+        'devices': [
+          {
+            'id': 'dev-uuid-1',
+            'identifier': 'device-1',
+            'manufacturer': 'Google',
+            'model': 'Pixel 7',
+            'platform': 'Android',
+            'platform_version': '14',
+          },
+        ],
+      };
+
+      final response = PaginatedResponse.fromJson(
+        json,
+        'devices',
+        Device.fromJson,
+      );
+      expect(response.count, 2);
+      expect(response.items.length, 1);
+      expect(response.items[0].id, 'dev-uuid-1');
+      expect(response.items[0].manufacturer, 'Google');
+    });
+
+    test('fromJson handles empty items list', () {
+      final json = {
+        'count': 0,
+        'current_page': 1,
+        'total_pages': 0,
+        'bug_reports': <dynamic>[],
+      };
+
+      final response = PaginatedResponse.fromJson(
+        json,
+        'bug_reports',
+        BugReport.fromJson,
+      );
+      expect(response.count, 0);
+      expect(response.items, isEmpty);
+    });
+  });
+
+  group('Device (v3 fields)', () {
+    test('fromJson parses id, timestamps, and nested associations', () {
+      final json = {
+        'id': 'dev-uuid-abc',
+        'identifier': 'device-id-123',
+        'manufacturer': 'Samsung',
+        'model': 'Galaxy S24',
+        'network_carrier': 'Verizon',
+        'platform': 'Android',
+        'platform_version': '14',
+        'created_at': '2026-01-01T00:00:00Z',
+        'updated_at': '2026-01-02T00:00:00Z',
+        'app_install': [
+          {
+            'id': 'ai-uuid-1',
+            'created_at': '2026-01-01T00:00:00Z',
+            'updated_at': '2026-01-01T00:00:00Z',
+            'app_version': {'id': 'av-uuid-1', 'name': '1.0.0', 'code': '1'},
+          },
+        ],
+        'device_status': [
+          {'id': 'ds-uuid-1', 'battery_level': 90},
+        ],
+      };
+
+      final device = Device.fromJson(json);
+      expect(device.id, 'dev-uuid-abc');
+      expect(device.identifier, 'device-id-123');
+      expect(device.manufacturer, 'Samsung');
+      expect(device.createdAt, '2026-01-01T00:00:00Z');
+      expect(device.updatedAt, '2026-01-02T00:00:00Z');
+      expect(device.appInstall, isNotNull);
+      expect(device.appInstall!.length, 1);
+      expect(device.appInstall![0].id, 'ai-uuid-1');
+      expect(device.appInstall![0].appVersion, isNotNull);
+      expect(device.appInstall![0].appVersion!.id, 'av-uuid-1');
+      expect(device.appInstall![0].appVersion!.name, '1.0.0');
+      expect(device.deviceStatus, isNotNull);
+      expect(device.deviceStatus!.length, 1);
+      expect(device.deviceStatus![0].id, 'ds-uuid-1');
+      expect(device.deviceStatus![0].batteryLevel, 90);
+    });
+
+    test('fromJson handles null nested associations', () {
+      final json = {
+        'id': 'dev-uuid-xyz',
+        'identifier': 'device-id-456',
+        'manufacturer': 'Apple',
+        'model': 'iPhone 16',
+        'platform': 'iOS',
+        'platform_version': '18',
+        'app_install': null,
+        'device_status': null,
+      };
+
+      final device = Device.fromJson(json);
+      expect(device.id, 'dev-uuid-xyz');
+      expect(device.appInstall, isNull);
+      expect(device.deviceStatus, isEmpty);
+    });
+
+    test('toJson still works for ping request (no new fields)', () {
+      final device = Device(
+        identifier: 'id-123',
+        manufacturer: 'Google',
+        model: 'Pixel',
+        platform: 'Android',
+        platformVersion: '14',
+      );
+      final json = device.toJson();
+      expect(json['identifier'], 'id-123');
+      expect(json.containsKey('id'), false);
+      expect(json.containsKey('app_install'), false);
+    });
+  });
+
+  group('AppInstall', () {
+    test('fromNestedJson parses with app_version', () {
+      final json = {
+        'id': 'ai-uuid-1',
+        'created_at': '2026-01-01T00:00:00Z',
+        'updated_at': '2026-01-02T00:00:00Z',
+        'app_version': {'id': 'av-uuid-1', 'name': '2.0.0', 'code': '42'},
+      };
+
+      final install = AppInstall.fromNestedJson(json);
+      expect(install.id, 'ai-uuid-1');
+      expect(install.createdAt, '2026-01-01T00:00:00Z');
+      expect(install.updatedAt, '2026-01-02T00:00:00Z');
+      expect(install.appVersion, isNotNull);
+      expect(install.appVersion!.id, 'av-uuid-1');
+      expect(install.appVersion!.name, '2.0.0');
+    });
+
+    test('fromNestedJson handles null app_version', () {
+      final json = {
+        'id': 'ai-uuid-2',
+        'created_at': null,
+        'updated_at': null,
+        'app_version': null,
+      };
+
+      final install = AppInstall.fromNestedJson(json);
+      expect(install.id, 'ai-uuid-2');
+      expect(install.appVersion, isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Add `listBugReports`, `getBugReport`, and `listDevices` v3 GET endpoints to `Api` and `Critic` classes
- Add `PaginatedResponse<T>` generic model for paginated API responses
- Add `DeviceStatus` model with all v3 serializer fields
- Update `Device` model with `id`, `createdAt`, `updatedAt`, nested `appInstall` and `deviceStatus`
- Update `AppInstall` with `fromNestedJson` factory for v3 device response parsing
- Add 12 new unit tests (26 total passing)

## Test plan
- [x] All 26 model tests pass (`fvm flutter test test/models_test.dart`)
- [x] `fvm flutter analyze` — no issues
- [x] `fvm dart format --set-exit-if-changed .` — no changes needed
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)