### PR TITLE
CRITIC-179: Confirm Flutter SDK has no GET endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # inventiv-critic-flutter
 
-This plugin allows Flutter apps to interact with the Inventiv Critic system for bug tracking and reporting. You will need to have a Critic account to properly utilize this. Please visit [the Critic website](https://critictracking.com/getting-started/) for more information.
+A Flutter client SDK for submitting bug reports to [Inventiv Critic](https://critictracking.com/getting-started/). This SDK is designed for embedding in end-user apps and supports only report submission — administrative endpoints (listing reports, fetching individual reports, listing devices) are not included and should be accessed through the Critic web portal or server-side API instead.
 
 ## How to use
 


### PR DESCRIPTION
## Summary

- Verified the Flutter client SDK does not contain GET endpoints (`listBugReports`, `getBugReport`, `listDevices`) — CRITIC-171 was never merged to `main`
- Confirmed no `appApiToken`, `PaginatedResponse`, or `DeviceStatus` models exist in the codebase
- Updated README to explicitly document SDK scope: client-only (ping + submit report), no admin/GET endpoints
- All 14 existing tests pass, `flutter analyze` clean, formatting verified

## Context

The GET endpoints were implemented on `origin/critic-171-flutter-add-new-v3-get-endpoints` but never merged. These endpoints use the app API token (an admin credential) which should not be embedded in end-user Flutter apps. This PR documents the SDK's intended scope to prevent future re-introduction.

## Test plan

- [x] `fvm flutter test` — all 14 tests pass
- [x] `fvm flutter analyze` — no issues
- [x] `dart format --set-exit-if-changed .` — no formatting changes needed
- [x] Verified no GET endpoint code, models, or tests exist in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)