### PR TITLE
feat: add tests, modernize example, prepare 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,42 @@
-## 1.1.0
-
-**BREAKING:** Directory rename and code quality cleanup.
-
-- Rename `lib/modal/` to `lib/model/` (fix longstanding typo)
-- Rename `ping_request_modal.dart` to `ping_request.dart`
-- Rename `report_request_modal.dart` to `report_request.dart`
-- Add `lib/inventiv_critic_flutter.dart` barrel exports file for a single clean import path
-- Replace `@required` annotations with `required` keyword
-- Remove `new` keyword usage per Dart style guide
-- Replace `Completer`/`.then()` pattern in `Api.submitReport` with `async`/`await`
-- Fix `Connectivity().checkConnectivity()` to handle `List<ConnectivityResult>` return type (connectivity_plus 7.x)
-
 ## 1.0.0
 
-**BREAKING:** Migrate from v2 to v3 API.
+First stable release with v3 API support, full test coverage, and modernized example app.
 
-- Change API base URL from `/api/v2` to `/api/v3`
+### API Changes (BREAKING)
+- Migrate from v2 to v3 API (base URL `/api/v2` → `/api/v3`)
 - `AppInstall.id` is now a `String` (UUID) instead of `int`
 - `BugReport` now includes `id`, `device`, `app`, and `appVersion` fields from v3 response
 - Add `AppVersion` model for v3 nested app version data
 - `Attachment.fromJson` now reads `url` field (was `file_url` in v2)
 - `Critic.initialize()` accepts an optional `baseUrl` parameter for custom API endpoints
-- Update repository URL from `critic_flutter` to `inventiv-critic-flutter`
-- Update README title to match new repo name
+
+### Code Quality
+- Rename `lib/modal/` to `lib/model/` (fix longstanding typo)
+- Add `lib/inventiv_critic_flutter.dart` barrel exports file for a single clean import path
+- Replace `@required` annotations with `required` keyword
+- Remove `new` keyword usage per Dart style guide
+- Replace `Completer`/`.then()` pattern in `Api.submitReport` with `async`/`await`
+- Fix `Connectivity().checkConnectivity()` to handle `List<ConnectivityResult>` return type
+- Add injectable HTTP client and device status provider for testability
+- Add proper error handling for `submitReport` non-success responses
+
+### Tests
+- Add unit tests for model serialization (UUID string handling, int→String migration)
+- Add unit tests for API request construction (PingRequest JSON, BugReportRequest fields)
+- Add mock HTTP tests for ping and submitReport endpoints
+- Add error handling tests (400, 401, 422, 500 responses, network errors)
+
+### Example App
+- Modernize example with Material 3 design
+- Add initialization status indicator
+- Add user identifier field
+- Add proper loading and error states
+- Update SDK constraints to >=3.7.0
+
+### Infrastructure
+- Add GitHub Actions CI workflow (flutter analyze + flutter test on PR/push)
+- Add nightly security CI (package age check, actions security audit)
+- Update repository URL to `inventiv-critic-flutter`
 
 ## 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,85 @@
-# inventiv-critic-flutter
+# inventiv_critic_flutter
 
-A Flutter client SDK for submitting bug reports to [Inventiv Critic](https://critictracking.com/getting-started/). This SDK is designed for embedding in end-user apps and supports only report submission — administrative endpoints (listing reports, fetching individual reports, listing devices) are not included and should be accessed through the Critic web portal or server-side API instead.
+A Flutter client SDK for submitting bug reports to [Inventiv Critic](https://critictracking.com/getting-started/). Supports the Critic v3 API. This SDK is designed for embedding in end-user apps and supports only report submission — administrative endpoints (listing reports, fetching individual reports, listing devices) are not included and should be accessed through the Critic web portal or server-side API instead.
 
-## How to use
+## Requirements
 
-Step 1: Initialize the Critic library using your api key:
+- Dart SDK >=3.7.0
+- Flutter 3.x
+- A Critic account and API token — visit [the Critic website](https://critictracking.com/getting-started/) for setup instructions.
 
+## Installation
+
+Add to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  inventiv_critic_flutter: ^1.0.0
 ```
-String key = 'your api key';
-Critic().initialize(key);
+
+Or use the git repository directly:
+
+```yaml
+dependencies:
+  inventiv_critic_flutter:
+    git:
+      url: https://github.com/twinsunllc/inventiv-critic-flutter.git
 ```
 
-Step 2: Create a new Bug Report using the .create const:
+## Usage
 
+### 1. Import the package
+
+```dart
+import 'package:inventiv_critic_flutter/inventiv_critic_flutter.dart';
 ```
-BugReport report = BugReport.create(
-    description: 'description text',
-    stepsToReproduce: 'steps to reproduce text',
+
+### 2. Initialize Critic
+
+Call `initialize` with your API token. This performs a ping to register the app install with Critic.
+
+```dart
+await Critic().initialize('your-api-token');
+```
+
+To use a custom API endpoint:
+
+```dart
+await Critic().initialize('your-api-token', baseUrl: 'https://your-server.com/api/v3');
+```
+
+### 3. Submit a bug report
+
+```dart
+final report = BugReport.create(
+  description: 'App crashes when tapping the save button',
+  stepsToReproduce: '1. Open settings\n2. Change name\n3. Tap save',
+  userIdentifier: 'user@example.com',
 );
+
+final submittedReport = await Critic().submitReport(report);
+print('Report submitted with ID: ${submittedReport.id}');
 ```
 
-Step 3: Attach a file, if necessary
+### 4. Attach files (optional)
 
-```
-File file = File('path to file');
-report.attachments = <Attachment>[];
-report.attachments!.add(Attachment(name: 'test file', path: file.path));
-```
+```dart
+final report = BugReport.create(
+  description: 'Layout broken on tablet',
+  stepsToReproduce: '1. Open on iPad\n2. Rotate to landscape',
+);
 
-Step 4: Use the Critic() singleton to submit your BugReport (example using Futures):
+report.attachments = [
+  Attachment(name: 'screenshot.png', path: '/path/to/screenshot.png'),
+];
 
-```
-Critic().submitReport(report).then(
-    (BugReport successfulReport) {
-      //success!
-    }).catchError((Object error) {
-      //failure
-    });
+await Critic().submitReport(report);
 ```
 
-Step 5: Review bugs submitted for your organization using [Critic's web portal](https://critic.inventiv.io)
+## Example
+
+See the [example app](example/) for a complete working demo with Material 3 UI.
+
+## License
+
+See [LICENSE](LICENSE) for details.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,92 +1,223 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-
 import 'package:inventiv_critic_flutter/critic.dart';
 import 'package:inventiv_critic_flutter/model/bug_report.dart';
 import 'package:path_provider/path_provider.dart';
 
-void main() => runApp(MyApp());
+void main() => runApp(const CriticExampleApp());
 
-class MyApp extends StatefulWidget {
-  @override
-  _MyAppState createState() => _MyAppState();
-}
-
-class _MyAppState extends State<MyApp> {
-  TextEditingController _descriptionController = TextEditingController(),
-      _reproduceController = TextEditingController();
-
-  @override
-  void initState() {
-    super.initState();
-    Critic().initialize('gJ44GxttrahyVBFs4k3jb8T1');
-  }
-
-  void _submitReport(BuildContext context, {bool withFile = false}) async {
-    BugReport report = BugReport.create(
-        description: _descriptionController.text,
-        stepsToReproduce: _reproduceController.text);
-
-    if (withFile) {
-      report.attachments = <Attachment>[];
-      Directory dir = await getApplicationDocumentsDirectory();
-      File file = File('${dir.path}/test.txt');
-      File writtenFile =
-          await file.writeAsString('Test file upload', mode: FileMode.write);
-      report.attachments
-          ?.add(Attachment(name: 'test file', path: writtenFile.path));
-    }
-
-    Critic().submitReport(report).then((BugReport successfulReport) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text('Bug Report has been filed, check console'),
-      ));
-      print(
-          'Successfully logged!\ndescription: ${successfulReport.description}\nsteps to reproduce: ${successfulReport.stepsToReproduce}');
-    }).catchError((Object error) {
-      print(error.toString());
-    });
-  }
+class CriticExampleApp extends StatelessWidget {
+  const CriticExampleApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Plugin example app'),
-        ),
-        body: Padding(
-          padding: const EdgeInsets.all(25.0),
-          child: Builder(
-            builder: (context) => Column(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: <Widget>[
-                Text('Enter a description'),
-                TextField(
-                  controller: _descriptionController,
+      title: 'Critic Example',
+      theme: ThemeData(colorSchemeSeed: Colors.indigo, useMaterial3: true),
+      home: const CriticExamplePage(),
+    );
+  }
+}
+
+class CriticExamplePage extends StatefulWidget {
+  const CriticExamplePage({super.key});
+
+  @override
+  State<CriticExamplePage> createState() => _CriticExamplePageState();
+}
+
+class _CriticExamplePageState extends State<CriticExamplePage> {
+  final _descriptionController = TextEditingController();
+  final _stepsController = TextEditingController();
+  final _userIdController = TextEditingController();
+
+  bool _initialized = false;
+  bool _initializing = false;
+  bool _submitting = false;
+  String? _statusMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeCritic();
+  }
+
+  Future<void> _initializeCritic() async {
+    setState(() => _initializing = true);
+    try {
+      await Critic().initialize('YOUR_API_TOKEN_HERE');
+      setState(() {
+        _initialized = true;
+        _statusMessage = 'Critic initialized successfully';
+      });
+    } catch (e) {
+      setState(() {
+        _statusMessage = 'Initialization failed: $e';
+      });
+    } finally {
+      setState(() => _initializing = false);
+    }
+  }
+
+  Future<void> _submitReport({bool withAttachment = false}) async {
+    if (!_initialized) {
+      _showSnackBar('Critic not initialized yet');
+      return;
+    }
+
+    if (_descriptionController.text.isEmpty) {
+      _showSnackBar('Please enter a description');
+      return;
+    }
+
+    setState(() => _submitting = true);
+
+    final report = BugReport.create(
+      description: _descriptionController.text,
+      stepsToReproduce:
+          _stepsController.text.isNotEmpty
+              ? _stepsController.text
+              : 'No steps provided',
+      userIdentifier:
+          _userIdController.text.isNotEmpty ? _userIdController.text : null,
+    );
+
+    if (withAttachment) {
+      final dir = await getApplicationDocumentsDirectory();
+      final file = File('${dir.path}/sample_attachment.txt');
+      await file.writeAsString(
+        'Sample attachment created at ${DateTime.now().toIso8601String()}',
+      );
+      report.attachments = [
+        Attachment(name: 'sample_attachment.txt', path: file.path),
+      ];
+    }
+
+    try {
+      final result = await Critic().submitReport(report);
+      _showSnackBar('Bug report submitted (ID: ${result.id})');
+      _descriptionController.clear();
+      _stepsController.clear();
+      _userIdController.clear();
+    } catch (e) {
+      _showSnackBar('Submission failed: $e');
+    } finally {
+      setState(() => _submitting = false);
+    }
+  }
+
+  void _showSnackBar(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  void dispose() {
+    _descriptionController.dispose();
+    _stepsController.dispose();
+    _userIdController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Critic Example')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Icon(
+                      _initialized
+                          ? Icons.check_circle
+                          : _initializing
+                          ? Icons.hourglass_top
+                          : Icons.error,
+                      color:
+                          _initialized
+                              ? Colors.green
+                              : _initializing
+                              ? Colors.orange
+                              : Colors.red,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        _statusMessage ?? 'Connecting to Critic...',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                    ),
+                  ],
                 ),
-                Text('Enter steps to reproduce'),
-                TextField(
-                  controller: _reproduceController,
-                ),
-                MaterialButton(
-                  color: Colors.grey,
-                  onPressed: () {
-                    _submitReport(context);
-                  },
-                  child: Text('Test Submit'),
-                ),
-                MaterialButton(
-                  color: Colors.grey,
-                  onPressed: () {
-                    _submitReport(context, withFile: true);
-                  },
-                  child: Text('Test Submit with file'),
-                ),
-              ],
+              ),
             ),
-          ),
+            const SizedBox(height: 24),
+            Text(
+              'Submit a Bug Report',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _descriptionController,
+              decoration: const InputDecoration(
+                labelText: 'Description',
+                hintText: 'Describe the bug...',
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 3,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _stepsController,
+              decoration: const InputDecoration(
+                labelText: 'Steps to Reproduce',
+                hintText: '1. Open the app\n2. Tap on...\n3. Observe...',
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 3,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _userIdController,
+              decoration: const InputDecoration(
+                labelText: 'User Identifier (optional)',
+                hintText: 'e.g. user@example.com',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed:
+                  _submitting || !_initialized ? null : () => _submitReport(),
+              icon:
+                  _submitting
+                      ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                      : const Icon(Icons.send),
+              label: const Text('Submit Report'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton.icon(
+              onPressed:
+                  _submitting || !_initialized
+                      ? null
+                      : () => _submitReport(withAttachment: true),
+              icon: const Icon(Icons.attach_file),
+              label: const Text('Submit with Attachment'),
+            ),
+          ],
         ),
       ),
     );

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the inventiv_critic_flutter plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/lib/api.dart
+++ b/lib/api.dart
@@ -11,8 +11,12 @@ import 'package:inventiv_critic_flutter/model/report_request.dart';
 
 const String _defaultApiUrl = 'https://critic.inventiv.io/api/v3';
 
+typedef DeviceStatusProvider = Future<Map<String, String>> Function();
+
 class Api {
   static String _apiUrl = _defaultApiUrl;
+  static http.Client? _httpClient;
+  static DeviceStatusProvider? _deviceStatusProvider;
 
   static void setBaseUrl(String url) {
     _apiUrl = url;
@@ -22,8 +26,30 @@ class Api {
     _apiUrl = _defaultApiUrl;
   }
 
+  /// Sets a custom HTTP client (useful for testing).
+  static void setHttpClient(http.Client client) {
+    _httpClient = client;
+  }
+
+  /// Resets the HTTP client to the default.
+  static void resetHttpClient() {
+    _httpClient = null;
+  }
+
+  /// Sets a custom device status provider (useful for testing).
+  static void setDeviceStatusProvider(DeviceStatusProvider provider) {
+    _deviceStatusProvider = provider;
+  }
+
+  /// Resets the device status provider to the default.
+  static void resetDeviceStatusProvider() {
+    _deviceStatusProvider = null;
+  }
+
+  static http.Client get _client => _httpClient ?? http.Client();
+
   static Future<AppInstall> ping(PingRequest pingRequest) async {
-    final response = await http.post(
+    final response = await _client.post(
       Uri.parse('$_apiUrl/ping'),
       body: json.encode(pingRequest.toJson()),
       headers: {HttpHeaders.contentTypeHeader: 'application/json'},
@@ -81,7 +107,7 @@ class Api {
               'no steps to reproduce'
           ..fields['bug_report[user_identifier]'] =
               submitReportRequest.report.userIdentifier ?? 'no user identifier'
-          ..fields.addAll(await Api.deviceStatus());
+          ..fields.addAll(await (_deviceStatusProvider ?? Api.deviceStatus)());
 
     if (submitReportRequest.report.attachments?.isNotEmpty ?? false) {
       await Future.wait(
@@ -99,10 +125,16 @@ class Api {
       );
     }
 
-    final response = await request.send();
-    print('Response: ${response.statusCode}');
-    final body = await response.stream.bytesToString();
+    final streamedResponse = await _client.send(request);
+    print('Response: ${streamedResponse.statusCode}');
+    final body = await streamedResponse.stream.bytesToString();
     print(body);
-    return BugReport.fromJson(json.decode(body));
+
+    if (streamedResponse.statusCode == 200 ||
+        streamedResponse.statusCode == 201) {
+      return BugReport.fromJson(json.decode(body));
+    } else {
+      throw Exception('Response code: ${streamedResponse.statusCode}, $body');
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: inventiv_critic_flutter
 description: A flutter plugin for Critic integration.
-version: 1.1.0
+version: 1.0.0
 homepage: https://www.twinsunsolutions.com
 repository: https://github.com/twinsunllc/inventiv-critic-flutter
 
@@ -20,3 +20,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  mocktail: ^1.0.4

--- a/test/api_test.dart
+++ b/test/api_test.dart
@@ -1,0 +1,497 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:inventiv_critic_flutter/api.dart';
+import 'package:inventiv_critic_flutter/model/app.dart';
+import 'package:inventiv_critic_flutter/model/bug_report.dart';
+import 'package:inventiv_critic_flutter/model/device.dart';
+import 'package:inventiv_critic_flutter/model/ping_request.dart';
+import 'package:inventiv_critic_flutter/model/ping_response.dart';
+import 'package:inventiv_critic_flutter/model/report_request.dart';
+
+void main() {
+  late PingRequest testPingRequest;
+
+  setUp(() {
+    Api.resetBaseUrl();
+    Api.resetHttpClient();
+    Api.setDeviceStatusProvider(
+      () async => <String, String>{
+        'device_status[network_cell_connected]': 'false',
+        'device_status[network_wifi_connected]': 'true',
+      },
+    );
+
+    testPingRequest = PingRequest(
+      apiToken: 'test-api-token',
+      app: App.create(
+        name: 'TestApp',
+        package: 'com.test.app',
+        platform: 'Android',
+        versionName: '1.0.0',
+        versionCode: '1',
+      ),
+      device: Device(
+        identifier: 'device-123',
+        manufacturer: 'Google',
+        model: 'Pixel 7',
+        networkCarrier: 'T-Mobile',
+        platform: 'Android',
+        platformVersion: '14',
+      ),
+    );
+  });
+
+  tearDown(() {
+    Api.resetBaseUrl();
+    Api.resetHttpClient();
+    Api.resetDeviceStatusProvider();
+  });
+
+  group('PingRequest serialization', () {
+    test('toJson includes api_token, app, and device', () {
+      final json = testPingRequest.toJson();
+
+      expect(json['api_token'], 'test-api-token');
+      expect(json['app'], isA<Map<String, dynamic>>());
+      expect(json['app']['name'], 'TestApp');
+      expect(json['app']['package'], 'com.test.app');
+      expect(json['app']['platform'], 'Android');
+      expect(json['app']['version']['name'], '1.0.0');
+      expect(json['app']['version']['code'], '1');
+      expect(json['device'], isA<Map<String, dynamic>>());
+      expect(json['device']['identifier'], 'device-123');
+      expect(json['device']['manufacturer'], 'Google');
+      expect(json['device']['platform'], 'Android');
+    });
+
+    test('toJson encodes to valid JSON string', () {
+      final encoded = json.encode(testPingRequest.toJson());
+      final decoded = json.decode(encoded);
+
+      expect(decoded, isA<Map<String, dynamic>>());
+      expect(decoded['api_token'], 'test-api-token');
+    });
+  });
+
+  group('BugReportRequest serialization', () {
+    test('toJson includes api_token, bug_report, and app_install', () {
+      final request = BugReportRequest(
+        appInstall: AppInstall(id: 'install-uuid-123'),
+        apiToken: 'test-token',
+        report: BugReport.create(
+          description: 'Test bug',
+          stepsToReproduce: 'Step 1\nStep 2',
+          userIdentifier: 'user@test.com',
+        ),
+      );
+
+      final jsonMap = request.toJson();
+      expect(jsonMap['api_token'], 'test-token');
+      expect(jsonMap['bug_report'], isA<BugReport>());
+      expect(jsonMap['app_install'], isA<AppInstall>());
+    });
+  });
+
+  group('Api.setBaseUrl / resetBaseUrl', () {
+    test('setBaseUrl changes the API URL used by ping', () async {
+      Api.setBaseUrl('https://custom.api.com/v3');
+
+      Uri? capturedUri;
+      final mockClient = MockClient((request) async {
+        capturedUri = request.url;
+        return http.Response(
+          json.encode({
+            'app_install': {'id': 'uuid-123'},
+          }),
+          200,
+        );
+      });
+      Api.setHttpClient(mockClient);
+
+      await Api.ping(testPingRequest);
+      expect(capturedUri.toString(), 'https://custom.api.com/v3/ping');
+    });
+
+    test('resetBaseUrl restores default URL', () async {
+      Api.setBaseUrl('https://custom.api.com/v3');
+      Api.resetBaseUrl();
+
+      Uri? capturedUri;
+      final mockClient = MockClient((request) async {
+        capturedUri = request.url;
+        return http.Response(
+          json.encode({
+            'app_install': {'id': 'uuid-123'},
+          }),
+          200,
+        );
+      });
+      Api.setHttpClient(mockClient);
+
+      await Api.ping(testPingRequest);
+      expect(capturedUri.toString(), 'https://critic.inventiv.io/api/v3/ping');
+    });
+  });
+
+  group('Api.ping', () {
+    test('sends POST with JSON body and content-type header', () async {
+      String? capturedBody;
+      Map<String, String>? capturedHeaders;
+      String? capturedMethod;
+
+      final mockClient = MockClient((request) async {
+        capturedMethod = request.method;
+        capturedBody = request.body;
+        capturedHeaders = request.headers;
+        return http.Response(
+          json.encode({
+            'app_install': {'id': 'uuid-response-123'},
+          }),
+          200,
+        );
+      });
+      Api.setHttpClient(mockClient);
+
+      await Api.ping(testPingRequest);
+
+      expect(capturedMethod, 'POST');
+      expect(capturedHeaders!['content-type'], 'application/json');
+
+      final decodedBody = json.decode(capturedBody!);
+      expect(decodedBody['api_token'], 'test-api-token');
+      expect(decodedBody['app']['name'], 'TestApp');
+      expect(decodedBody['device']['manufacturer'], 'Google');
+    });
+
+    test('returns AppInstall on 200 response', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response(
+          json.encode({
+            'app_install': {'id': 'uuid-success-456'},
+          }),
+          200,
+        );
+      });
+      Api.setHttpClient(mockClient);
+
+      final result = await Api.ping(testPingRequest);
+      expect(result, isA<AppInstall>());
+      expect(result.id, 'uuid-success-456');
+    });
+
+    test('returns AppInstall with integer id converted to string', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response(
+          json.encode({
+            'app_install': {'id': 42},
+          }),
+          200,
+        );
+      });
+      Api.setHttpClient(mockClient);
+
+      final result = await Api.ping(testPingRequest);
+      expect(result.id, '42');
+    });
+
+    test('throws Exception on 400 response', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('{"error": "Invalid token"}', 400);
+      });
+      Api.setHttpClient(mockClient);
+
+      expect(
+        () => Api.ping(testPingRequest),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Response code: 400'),
+          ),
+        ),
+      );
+    });
+
+    test('throws Exception on 401 unauthorized', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('Unauthorized', 401);
+      });
+      Api.setHttpClient(mockClient);
+
+      expect(
+        () => Api.ping(testPingRequest),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Response code: 401'),
+          ),
+        ),
+      );
+    });
+
+    test('throws Exception on 500 server error', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('Internal Server Error', 500);
+      });
+      Api.setHttpClient(mockClient);
+
+      expect(
+        () => Api.ping(testPingRequest),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Response code: 500'),
+          ),
+        ),
+      );
+    });
+
+    test('throws on network error', () async {
+      final mockClient = MockClient((request) async {
+        throw http.ClientException('Connection refused');
+      });
+      Api.setHttpClient(mockClient);
+
+      expect(
+        () => Api.ping(testPingRequest),
+        throwsA(isA<http.ClientException>()),
+      );
+    });
+  });
+
+  group('Api.submitReport', () {
+    late BugReportRequest testReportRequest;
+
+    setUp(() {
+      testReportRequest = BugReportRequest(
+        appInstall: AppInstall(id: 'install-uuid-789'),
+        apiToken: 'test-api-token',
+        report: BugReport.create(
+          description: 'App crashes on login',
+          stepsToReproduce: '1. Open app\n2. Tap login\n3. App crashes',
+          userIdentifier: 'user@example.com',
+        ),
+      );
+    });
+
+    test('sends POST multipart request to bug_reports endpoint', () async {
+      String? capturedMethod;
+      Uri? capturedUri;
+
+      final mockClient = MockClient.streaming((request, bodyStream) async {
+        capturedMethod = request.method;
+        capturedUri = request.url;
+        // Drain the body stream
+        await bodyStream.drain<void>();
+        return http.StreamedResponse(
+          Stream.value(
+            utf8.encode(
+              json.encode({
+                'id': 'bug-uuid-result',
+                'description': 'App crashes on login',
+                'steps_to_reproduce':
+                    '1. Open app\n2. Tap login\n3. App crashes',
+                'user_identifier': 'user@example.com',
+                'created_at': '2026-01-01T00:00:00Z',
+                'updated_at': '2026-01-01T00:00:00Z',
+                'attachments': [],
+              }),
+            ),
+          ),
+          200,
+        );
+      });
+      Api.setHttpClient(mockClient);
+
+      await Api.submitReport(testReportRequest);
+
+      expect(capturedMethod, 'POST');
+      expect(
+        capturedUri.toString(),
+        'https://critic.inventiv.io/api/v3/bug_reports',
+      );
+    });
+
+    test('includes correct multipart form fields', () async {
+      String? capturedContentType;
+
+      final mockClient = MockClient.streaming((request, bodyStream) async {
+        capturedContentType = request.headers['content-type'];
+        await bodyStream.drain<void>();
+        return http.StreamedResponse(
+          Stream.value(
+            utf8.encode(
+              json.encode({
+                'id': 'bug-uuid',
+                'description': 'App crashes on login',
+                'steps_to_reproduce': '1. Open app',
+                'user_identifier': 'user@example.com',
+                'created_at': null,
+                'updated_at': null,
+                'attachments': [],
+              }),
+            ),
+          ),
+          200,
+        );
+      });
+      Api.setHttpClient(mockClient);
+
+      await Api.submitReport(testReportRequest);
+
+      expect(capturedContentType, contains('multipart/form-data'));
+    });
+
+    test('returns BugReport on 200 response', () async {
+      final mockClient = MockClient.streaming((request, bodyStream) async {
+        await bodyStream.drain<void>();
+        return http.StreamedResponse(
+          Stream.value(
+            utf8.encode(
+              json.encode({
+                'id': 'bug-uuid-created',
+                'description': 'App crashes on login',
+                'steps_to_reproduce':
+                    '1. Open app\n2. Tap login\n3. App crashes',
+                'user_identifier': 'user@example.com',
+                'created_at': '2026-01-01T00:00:00Z',
+                'updated_at': '2026-01-01T00:00:00Z',
+                'attachments': [],
+              }),
+            ),
+          ),
+          200,
+        );
+      });
+      Api.setHttpClient(mockClient);
+
+      final result = await Api.submitReport(testReportRequest);
+      expect(result, isA<BugReport>());
+      expect(result.id, 'bug-uuid-created');
+      expect(result.description, 'App crashes on login');
+    });
+
+    test('returns BugReport on 201 response', () async {
+      final mockClient = MockClient.streaming((request, bodyStream) async {
+        await bodyStream.drain<void>();
+        return http.StreamedResponse(
+          Stream.value(
+            utf8.encode(
+              json.encode({
+                'id': 'bug-uuid-201',
+                'description': 'Test',
+                'steps_to_reproduce': 'Steps',
+                'user_identifier': 'user',
+                'created_at': null,
+                'updated_at': null,
+                'attachments': [],
+              }),
+            ),
+          ),
+          201,
+        );
+      });
+      Api.setHttpClient(mockClient);
+
+      final result = await Api.submitReport(testReportRequest);
+      expect(result.id, 'bug-uuid-201');
+    });
+
+    test('throws Exception on 422 validation error', () async {
+      final mockClient = MockClient.streaming((request, bodyStream) async {
+        await bodyStream.drain<void>();
+        return http.StreamedResponse(
+          Stream.value(utf8.encode('{"error": "Validation failed"}')),
+          422,
+        );
+      });
+      Api.setHttpClient(mockClient);
+
+      expect(
+        () => Api.submitReport(testReportRequest),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Response code: 422'),
+          ),
+        ),
+      );
+    });
+
+    test('throws Exception on 500 server error', () async {
+      final mockClient = MockClient.streaming((request, bodyStream) async {
+        await bodyStream.drain<void>();
+        return http.StreamedResponse(
+          Stream.value(utf8.encode('Internal Server Error')),
+          500,
+        );
+      });
+      Api.setHttpClient(mockClient);
+
+      expect(
+        () => Api.submitReport(testReportRequest),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Response code: 500'),
+          ),
+        ),
+      );
+    });
+
+    test('uses default values for null report fields', () async {
+      final requestWithNulls = BugReportRequest(
+        appInstall: AppInstall(id: 'install-uuid'),
+        apiToken: 'token',
+        report: BugReport(
+          description: null,
+          stepsToReproduce: null,
+          userIdentifier: null,
+        ),
+      );
+
+      final mockClient = MockClient.streaming((request, bodyStream) async {
+        await bodyStream.drain<void>();
+        return http.StreamedResponse(
+          Stream.value(
+            utf8.encode(
+              json.encode({
+                'id': 'bug-uuid',
+                'description': 'no description',
+                'steps_to_reproduce': 'no steps to reproduce',
+                'user_identifier': 'no user identifier',
+                'created_at': null,
+                'updated_at': null,
+                'attachments': [],
+              }),
+            ),
+          ),
+          200,
+        );
+      });
+      Api.setHttpClient(mockClient);
+
+      final result = await Api.submitReport(requestWithNulls);
+      expect(result, isA<BugReport>());
+    });
+
+    test('throws on network error', () async {
+      final mockClient = MockClient.streaming((request, bodyStream) async {
+        throw http.ClientException('Connection timeout');
+      });
+      Api.setHttpClient(mockClient);
+
+      expect(
+        () => Api.submitReport(testReportRequest),
+        throwsA(isA<http.ClientException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add comprehensive test suite: 20 new API tests (mock HTTP for ping/submitReport, error handling for 400/401/422/500, network errors) plus 14 existing model tests
- Modernize example app with Material 3 design, initialization status indicator, and proper loading/error states
- Prepare 1.0.0 release: update version, consolidate CHANGELOG, rewrite README with v3 usage examples
- Add injectable HTTP client and device status provider to `Api` class for testability
- Add proper error handling for `submitReport` non-success responses

## Test plan
- [x] All 34 unit tests pass (`fvm flutter test`)
- [x] `fvm flutter analyze` — no issues found
- [x] `dart format --set-exit-if-changed .` — all files formatted
- [x] Version set to 1.0.0 in pubspec.yaml (NOT published to pub.dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)