### PR TITLE
feat: standardize log attachment filename to console-logs.txt

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -164,7 +164,7 @@ class Api {
           http.MultipartFile.fromString(
             'bug_report[attachments][]',
             logContent,
-            filename: 'console_log.txt',
+            filename: 'console-logs.txt',
           ),
         );
       } catch (e) {

--- a/test/api_test.dart
+++ b/test/api_test.dart
@@ -702,7 +702,7 @@ void main() {
       );
     });
 
-    test('attaches console_log.txt when logBuffer has entries', () async {
+    test('attaches console-logs.txt when logBuffer has entries', () async {
       final logBuffer = LogBuffer();
       logBuffer.add('Log line 1');
       logBuffer.add('Log line 2');
@@ -732,7 +732,7 @@ void main() {
 
       await Api.submitReport(testReportRequest, logBuffer: logBuffer);
 
-      expect(capturedBody, contains('console_log.txt'));
+      expect(capturedBody, contains('console-logs.txt'));
       expect(capturedBody, contains('Log line 1'));
       expect(capturedBody, contains('Log line 2'));
     });
@@ -765,7 +765,7 @@ void main() {
 
       await Api.submitReport(testReportRequest, logBuffer: logBuffer);
 
-      expect(capturedBody, isNot(contains('console_log.txt')));
+      expect(capturedBody, isNot(contains('console-logs.txt')));
     });
 
     test('does not attach log file when logBuffer is null', () async {
@@ -794,7 +794,7 @@ void main() {
 
       await Api.submitReport(testReportRequest);
 
-      expect(capturedBody, isNot(contains('console_log.txt')));
+      expect(capturedBody, isNot(contains('console-logs.txt')));
     });
 
     test('report still submits when logBuffer is provided', () async {


### PR DESCRIPTION
## Summary
- Rename log attachment filename from `console_log.txt` to `console-logs.txt` in `Api.submitReport()`
- Update tests to match the new filename

## Test plan
- [ ] `fvm flutter test test/api_test.dart` — all 28 tests pass
- [ ] `fvm flutter analyze` — no issues
- [ ] `fvm dart format --set-exit-if-changed .` — no formatting changes

Closes CRITIC-227

🤖 Generated with [Claude Code](https://claude.com/claude-code)