### PR TITLE
CRITIC-242: Update CHANGELOG for 1.0.0 and add GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Version tag to release (e.g. v1.0.0)"
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  test:
+    name: Flutter Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046  # v2.19.0
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: dart analyze --fatal-warnings
+      - name: Run tests
+        run: |
+          if [ -d "test" ]; then
+            flutter test
+          else
+            echo "No test directory found — skipping tests"
+          fi
+
+  release:
+    name: Create GitHub Release
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Extract the section for the current version from CHANGELOG.md
+          # Grab everything between "## <version>" and the next "## " heading
+          NOTES=$(awk "/^## ${VERSION}$/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES="See CHANGELOG.md for release notes."
+          fi
+          # Write to a file to avoid quoting issues with multiline strings
+          echo "$NOTES" > /tmp/release-notes.md
+          cat /tmp/release-notes.md
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          release_name: ${{ steps.version.outputs.tag }}
+          body_path: /tmp/release-notes.md
+          draft: false
+          prerelease: false
+
+  publish:
+    name: Publish to pub.dev
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046  # v2.19.0
+        with:
+          channel: stable
+      - run: flutter pub get
+
+      - name: Publish to pub.dev
+        run: flutter pub publish --force
+        env:
+          # Set PUB_DEV_CREDENTIALS to a JSON credentials file obtained from
+          # `dart pub token add https://pub.dev` on a machine authenticated
+          # with a verified pub.dev publisher account. Store the JSON content
+          # as the PUB_DEV_CREDENTIALS repository secret.
+          PUB_CREDENTIALS: ${{ secrets.PUB_DEV_CREDENTIALS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,11 @@ jobs:
         id: changelog
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          # Escape dots so awk treats them as literal characters, not regex wildcards
+          ESCAPED_VERSION=$(echo "$VERSION" | sed 's/\./\\./g')
           # Extract the section for the current version from CHANGELOG.md
           # Grab everything between "## <version>" and the next "## " heading
-          NOTES=$(awk "/^## ${VERSION}$/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md)
+          NOTES=$(awk "/^## ${ESCAPED_VERSION}$/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md)
           if [ -z "$NOTES" ]; then
             NOTES="See CHANGELOG.md for release notes."
           fi
@@ -68,15 +70,11 @@ jobs:
           cat /tmp/release-notes.md
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.x
         with:
           tag_name: ${{ steps.version.outputs.tag }}
-          release_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
           body_path: /tmp/release-notes.md
-          draft: false
-          prerelease: false
 
   publish:
     name: Publish to pub.dev
@@ -89,11 +87,9 @@ jobs:
           channel: stable
       - run: flutter pub get
 
+      - name: Configure pub.dev credentials
+        run: |
+          mkdir -p ~/.pub-cache
+          echo '${{ secrets.PUB_DEV_CREDENTIALS }}' > ~/.pub-cache/credentials.json
       - name: Publish to pub.dev
         run: flutter pub publish --force
-        env:
-          # Set PUB_DEV_CREDENTIALS to a JSON credentials file obtained from
-          # `dart pub token add https://pub.dev` on a machine authenticated
-          # with a verified pub.dev publisher account. Store the JSON content
-          # as the PUB_DEV_CREDENTIALS repository secret.
-          PUB_CREDENTIALS: ${{ secrets.PUB_DEV_CREDENTIALS }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ First stable release with v3 API support, full test coverage, and modernized exa
 - `Attachment.fromJson` now reads `url` field (was `file_url` in v2)
 - `Critic.initialize()` accepts an optional `baseUrl` parameter for custom API endpoints
 
+### New Features
+- Add `LogCapture` class: intercepts `print()` calls via Dart `Zone` and captures `FlutterError.onError` for automatic inclusion in bug reports
+- Add `LogBuffer` ring buffer: fixed-capacity (default 500 entries) timestamped log store with bounded memory usage; oldest entries are evicted when full
+- Add disk space and memory info to device status included in bug reports
+
+### Bug Fixes
+- Fix `App.fromJson` null safety for `name` and `platform` fields (CRITIC-236)
+
 ### Code Quality
 - Rename `lib/modal/` to `lib/model/` (fix longstanding typo)
 - Add `lib/inventiv_critic_flutter.dart` barrel exports file for a single clean import path
@@ -19,6 +27,7 @@ First stable release with v3 API support, full test coverage, and modernized exa
 - Fix `Connectivity().checkConnectivity()` to handle `List<ConnectivityResult>` return type
 - Add injectable HTTP client and device status provider for testability
 - Add proper error handling for `submitReport` non-success responses
+- Standardize log attachment filename to `console-logs.txt`
 
 ### Tests
 - Add unit tests for model serialization (UUID string handling, int→String migration)


### PR DESCRIPTION
## Summary

- Updates `CHANGELOG.md` for the 1.0.0 release with previously missing entries: Zone-based log capture (`LogCapture`), ring buffer (`LogBuffer`), `App.fromJson` null safety fix (CRITIC-236), `console-logs.txt` filename standardization, and disk/memory device info
- Adds `.github/workflows/release.yml` triggered on `v*.*.*` tag push or manual dispatch; runs `flutter test`, creates a GitHub Release with extracted changelog notes, and publishes to pub.dev via `flutter pub publish --force` (requires `PUB_DEV_CREDENTIALS` secret)

## Test plan

- [ ] Verify CHANGELOG.md 1.0.0 section accurately reflects all features shipped in git history
- [ ] Confirm `flutter analyze` passes with no issues
- [ ] Confirm `dart format` reports no changes
- [ ] Review release.yml workflow: test → GitHub Release → pub.dev publish sequence
- [ ] After PR merges, create `v1.0.0` tag to trigger the release workflow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)