### PR TITLE
CRITIC-250: Switch publish job to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,16 +80,14 @@ jobs:
     name: Publish to pub.dev
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC trusted publishing
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: dart-lang/setup-dart@v1
       - uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046  # v2.19.0
         with:
           channel: stable
       - run: flutter pub get
-
-      - name: Configure pub.dev credentials
-        run: |
-          mkdir -p ~/.pub-cache
-          echo '${{ secrets.PUB_DEV_CREDENTIALS }}' > ~/.pub-cache/credentials.json
       - name: Publish to pub.dev
-        run: flutter pub publish --force
+        run: dart pub publish --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
       id-token: write  # Required for OIDC trusted publishing
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-      - uses: dart-lang/setup-dart@v1
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c  # v1
       - uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046  # v2.19.0
         with:
           channel: stable


### PR DESCRIPTION
## Summary

- Add `permissions: id-token: write` to the `publish` job for OIDC token access
- Add `dart-lang/setup-dart@v1` action to enable OIDC token exchange with pub.dev
- Remove the `Configure pub.dev credentials` step that wrote `PUB_DEV_CREDENTIALS` secret to `~/.pub-cache/credentials.json`
- Replace `flutter pub publish --force` with `dart pub publish --force`

## Test plan

- [ ] Verify the workflow YAML is valid (no syntax errors)
- [ ] Confirm no reference to `PUB_DEV_CREDENTIALS` secret remains in the publish job
- [ ] Confirm `id-token: write` permission is present on the publish job
- [ ] Confirm `dart-lang/setup-dart` step is present before the publish step
- [ ] Confirm `dart pub publish --force` is used instead of `flutter pub publish --force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)