### PR TITLE
Fix Nightly Security workflow: add softprops and dart-lang to allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowlist: |
             actions
+            dart-lang
+            softprops
             subosito
             twinsunllc
       - name: Upload audit report


### PR DESCRIPTION
## Summary

- The Nightly Security workflow was failing because `softprops/action-gh-release` and `dart-lang/setup-dart` are used in `release.yml` but were missing from the security checker's allowlist
- Added `softprops` and `dart-lang` to the `allowlist` in the `actions-security` job in `ci.yml`
- Both actions are already pinned to commit SHAs (passing the hash-pinning check); only the verified publisher check was failing

## Test plan

- [ ] Push triggers the Nightly Security workflow (or run via workflow_dispatch) and both previously-failing actions now pass
- [ ] No other workflow steps are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)