### PR TITLE
feat: expose public captureLog() API for third-party loggers (CRITIC-268)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,73 @@ report.attachments = [
 await Critic().submitReport(report);
 ```
 
+## Capturing logs from third-party loggers
+
+The SDK exposes `Critic.instance.captureLog()` so you can forward messages from
+any logging package directly into the `console-logs.txt` attachment. The SDK
+itself has **no dependency** on any logging library — you wire it in your own
+app code.
+
+```dart
+void captureLog(
+  String message, {
+  String? level,     // e.g. "info", "warning", "severe"
+  String? tag,       // e.g. logger name or subsystem
+  DateTime? timestamp,
+})
+```
+
+### package:logging
+
+```dart
+Logger.root.level = Level.ALL;
+Logger.root.onRecord.listen((record) {
+  Critic.instance.captureLog(
+    record.message,
+    level: record.level.name,
+    tag: record.loggerName,
+    timestamp: record.time,
+  );
+});
+```
+
+### package:logger
+
+Write a small `LogOutput` subclass that forwards to `captureLog`:
+
+```dart
+class CriticLogOutput extends LogOutput {
+  @override
+  void output(OutputEvent event) {
+    for (final line in event.lines) {
+      Critic.instance.captureLog(line, level: event.level.name);
+    }
+  }
+}
+
+// Then pass it to your Logger:
+final logger = Logger(output: CriticLogOutput());
+```
+
+### dart:developer log()
+
+Calls to `dart:developer`'s `log()` bypass the Dart Zone mechanism and go
+directly to the VM service, so they cannot be intercepted automatically.
+Forward them explicitly:
+
+```dart
+import 'dart:developer' as dev;
+
+void myLog(String message, {String? name}) {
+  dev.log(message, name: name ?? '');
+  Critic.instance.captureLog(message, tag: name);
+}
+```
+
 ## Example
 
-See the [example app](example/) for a complete working demo with Material 3 UI.
+See the [example app](example/) for a complete working demo with Material 3 UI,
+including a `package:logging` wiring example.
 
 ## License
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,16 +3,39 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:inventiv_critic_flutter/critic.dart';
 import 'package:inventiv_critic_flutter/model/bug_report.dart';
+import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
+
+/// Wire [package:logging] into Critic so every log record appears in the
+/// console-logs.txt attachment submitted with bug reports.
+///
+/// Note: [package:logging] is a dev dependency of this *example*; it is
+/// intentionally NOT a dependency of the inventiv_critic_flutter SDK itself.
+void _setupLogging() {
+  Logger.root.level = Level.ALL;
+  Logger.root.onRecord.listen((record) {
+    Critic.instance.captureLog(
+      record.message,
+      level: record.level.name,
+      tag: record.loggerName,
+      timestamp: record.time,
+    );
+  });
+}
+
+final _log = Logger('CriticExample');
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  _setupLogging();
   try {
     await Critic().initializeAndRun(
       'YOUR_API_TOKEN_HERE',
       () => runApp(const CriticExampleApp()),
     );
+    _log.info('Critic initialized successfully');
   } catch (e) {
+    _log.severe('Critic initialization failed: $e');
     runApp(CriticErrorApp(message: e.toString()));
   }
 }
@@ -98,12 +121,15 @@ class _CriticExamplePageState extends State<CriticExamplePage> {
     }
 
     try {
+      _log.info('Submitting bug report…');
       final result = await Critic().submitReport(report);
+      _log.info('Bug report submitted (ID: ${result.id})');
       _showSnackBar('Bug report submitted (ID: ${result.id})');
       _descriptionController.clear();
       _stepsController.clear();
       _userIdController.clear();
     } catch (e) {
+      _log.warning('Bug report submission failed: $e');
       _showSnackBar('Submission failed: $e');
     } finally {
       setState(() => _submitting = false);

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  logging: ^1.2.0
 
 flutter:
   uses-material-design: true

--- a/lib/critic.dart
+++ b/lib/critic.dart
@@ -22,6 +22,11 @@ class Critic {
     return _singleton;
   }
 
+  /// Returns the singleton [Critic] instance.
+  ///
+  /// Equivalent to calling `Critic()`.
+  static Critic get instance => _singleton;
+
   String? _apiToken;
   String? _appId;
 
@@ -117,6 +122,44 @@ class Critic {
   }) async {
     final zone = await initialize(apiToken, baseUrl: baseUrl);
     zone.run(body);
+  }
+
+  /// Writes a log entry directly into the SDK's log buffer.
+  ///
+  /// Use this to forward messages from third-party loggers (such as
+  /// `package:logging`, `package:logger`, or `package:talker`) so they appear
+  /// in the `console-logs.txt` attachment alongside `print()` output and
+  /// Flutter framework errors.
+  ///
+  /// - [message]: the log message text.
+  /// - [level]: optional severity label (e.g. `"info"`, `"warning"`,
+  ///   `"severe"`). Pass the value your logging library already produces.
+  /// - [tag]: optional category or logger name (e.g. `"AuthService"`).
+  /// - [timestamp]: optional point-in-time for the entry. Defaults to now.
+  ///
+  /// Example — wiring `package:logging`:
+  /// ```dart
+  /// Logger.root.onRecord.listen((record) {
+  ///   Critic.instance.captureLog(
+  ///     record.message,
+  ///     level: record.level.name,
+  ///     tag: record.loggerName,
+  ///     timestamp: record.time,
+  ///   );
+  /// });
+  /// ```
+  void captureLog(
+    String message, {
+    String? level,
+    String? tag,
+    DateTime? timestamp,
+  }) {
+    logCapture.buffer.add(
+      message,
+      level: level,
+      tag: tag,
+      timestamp: timestamp,
+    );
   }
 
   Future<BugReport> submitReport(BugReport report) async {

--- a/lib/log_buffer.dart
+++ b/lib/log_buffer.dart
@@ -19,15 +19,23 @@ class LogBuffer {
   /// Whether the buffer contains no entries.
   bool get isEmpty => _entries.isEmpty;
 
-  /// Add a log [message] with an optional [timestamp].
+  /// Add a log [message] with optional [level], [tag], and [timestamp].
+  ///
+  /// [level] is a free-form severity label (e.g. `"info"`, `"warning"`).
+  /// [tag] is a free-form category or logger name (e.g. `"MyService"`).
   ///
   /// If the buffer is at capacity the oldest entry is evicted.
-  void add(String message, {DateTime? timestamp}) {
+  void add(String message, {String? level, String? tag, DateTime? timestamp}) {
     if (_entries.length >= capacity) {
       _entries.removeFirst();
     }
     _entries.addLast(
-      LogEntry(message: message, timestamp: timestamp ?? DateTime.now()),
+      LogEntry(
+        message: message,
+        level: level,
+        tag: tag,
+        timestamp: timestamp ?? DateTime.now(),
+      ),
     );
   }
 
@@ -36,10 +44,28 @@ class LogBuffer {
 
   /// Formats the entire buffer as a single string suitable for writing to a
   /// text file attachment.
+  ///
+  /// Each line has the format:
+  /// `{timestamp}  [{level}] {tag}: {message}` when level/tag are present,
+  /// or `{timestamp}  {message}` for entries without metadata.
   String export() {
     final buf = StringBuffer();
     for (final entry in _entries) {
-      buf.writeln('${entry.timestamp.toIso8601String()}  ${entry.message}');
+      final prefix = StringBuffer();
+      if (entry.level != null) {
+        prefix.write('[${entry.level}]');
+      }
+      if (entry.tag != null) {
+        if (prefix.isNotEmpty) prefix.write(' ');
+        prefix.write('${entry.tag}:');
+      }
+      if (prefix.isNotEmpty) {
+        buf.writeln(
+          '${entry.timestamp.toIso8601String()}  $prefix ${entry.message}',
+        );
+      } else {
+        buf.writeln('${entry.timestamp.toIso8601String()}  ${entry.message}');
+      }
     }
     return buf.toString();
   }
@@ -51,7 +77,14 @@ class LogBuffer {
 /// A single timestamped log entry.
 class LogEntry {
   final String message;
+  final String? level;
+  final String? tag;
   final DateTime timestamp;
 
-  const LogEntry({required this.message, required this.timestamp});
+  const LogEntry({
+    required this.message,
+    this.level,
+    this.tag,
+    required this.timestamp,
+  });
 }

--- a/test/capture_log_test.dart
+++ b/test/capture_log_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:inventiv_critic_flutter/critic.dart';
+import 'package:inventiv_critic_flutter/log_buffer.dart';
+
+void main() {
+  group('Critic.captureLog', () {
+    late LogBuffer buffer;
+
+    setUp(() {
+      // Access the shared LogCapture buffer directly to inspect captured entries.
+      buffer = Critic.instance.logCapture.buffer;
+      buffer.clear();
+    });
+
+    tearDown(() {
+      buffer.clear();
+    });
+
+    test('captureLog() adds entry to the log buffer', () {
+      Critic.instance.captureLog('hello');
+      expect(buffer.length, 1);
+      expect(buffer.entries.first.message, 'hello');
+    });
+
+    test('captureLog() stores level on the entry', () {
+      Critic.instance.captureLog('msg', level: 'info');
+      expect(buffer.entries.first.level, 'info');
+    });
+
+    test('captureLog() stores tag on the entry', () {
+      Critic.instance.captureLog('msg', tag: 'MyLogger');
+      expect(buffer.entries.first.tag, 'MyLogger');
+    });
+
+    test('captureLog() stores all optional metadata', () {
+      final ts = DateTime(2026, 4, 9, 12, 0, 0);
+      Critic.instance.captureLog(
+        'structured log',
+        level: 'warning',
+        tag: 'AuthService',
+        timestamp: ts,
+      );
+      final entry = buffer.entries.first;
+      expect(entry.message, 'structured log');
+      expect(entry.level, 'warning');
+      expect(entry.tag, 'AuthService');
+      expect(entry.timestamp, ts);
+    });
+
+    test('captureLog() defaults timestamp to now when not provided', () {
+      final before = DateTime.now().subtract(const Duration(seconds: 1));
+      Critic.instance.captureLog('time test');
+      final after = DateTime.now().add(const Duration(seconds: 1));
+      final ts = buffer.entries.first.timestamp;
+      expect(ts.isAfter(before), isTrue);
+      expect(ts.isBefore(after), isTrue);
+    });
+
+    test('captureLog() level and tag are null when omitted', () {
+      Critic.instance.captureLog('plain');
+      final entry = buffer.entries.first;
+      expect(entry.level, isNull);
+      expect(entry.tag, isNull);
+    });
+
+    test('captureLog() entries appear in export() output', () {
+      final ts = DateTime(2026, 4, 9, 10, 0, 0);
+      Critic.instance.captureLog(
+        'exported log',
+        level: 'info',
+        tag: 'App',
+        timestamp: ts,
+      );
+      final output = buffer.export();
+      expect(output, contains('exported log'));
+      expect(output, contains('[info]'));
+      expect(output, contains('App:'));
+    });
+
+    test('captureLog() multiple entries are captured in order', () {
+      Critic.instance.captureLog('first', level: 'debug');
+      Critic.instance.captureLog('second', level: 'info');
+      Critic.instance.captureLog('third', level: 'warning');
+      expect(buffer.length, 3);
+      expect(buffer.entries[0].message, 'first');
+      expect(buffer.entries[1].message, 'second');
+      expect(buffer.entries[2].message, 'third');
+    });
+
+    test('Critic.instance returns the same singleton as Critic()', () {
+      expect(identical(Critic.instance, Critic()), isTrue);
+    });
+
+    test('captureLog() entries share the buffer with print() capture', () {
+      // Verify captureLog writes to the same buffer accessed via logCapture.
+      final directBuffer = Critic.instance.logCapture.buffer;
+      Critic.instance.captureLog('from logger');
+      expect(
+        directBuffer.entries.any((e) => e.message == 'from logger'),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/log_buffer_test.dart
+++ b/test/log_buffer_test.dart
@@ -99,5 +99,85 @@ void main() {
         throwsA(isA<UnsupportedError>()),
       );
     });
+
+    test('add() stores level on entry', () {
+      final buffer = LogBuffer();
+      buffer.add('msg', level: 'warning');
+      expect(buffer.entries.first.level, 'warning');
+    });
+
+    test('add() stores tag on entry', () {
+      final buffer = LogBuffer();
+      buffer.add('msg', tag: 'MyService');
+      expect(buffer.entries.first.tag, 'MyService');
+    });
+
+    test('add() stores both level and tag', () {
+      final buffer = LogBuffer();
+      buffer.add('hello', level: 'info', tag: 'AuthService');
+      final entry = buffer.entries.first;
+      expect(entry.level, 'info');
+      expect(entry.tag, 'AuthService');
+      expect(entry.message, 'hello');
+    });
+
+    test('level and tag default to null when not provided', () {
+      final buffer = LogBuffer();
+      buffer.add('plain');
+      final entry = buffer.entries.first;
+      expect(entry.level, isNull);
+      expect(entry.tag, isNull);
+    });
+
+    test('export() includes level and tag in formatted output', () {
+      final buffer = LogBuffer();
+      final ts = DateTime(2026, 1, 15, 12, 0, 0);
+      buffer.add('login attempt', level: 'info', tag: 'Auth', timestamp: ts);
+      final output = buffer.export();
+      expect(output, contains('[info]'));
+      expect(output, contains('Auth:'));
+      expect(output, contains('login attempt'));
+    });
+
+    test('export() includes only level when tag is absent', () {
+      final buffer = LogBuffer();
+      final ts = DateTime(2026, 1, 15, 12, 0, 0);
+      buffer.add('something', level: 'severe', timestamp: ts);
+      final output = buffer.export();
+      expect(output, contains('[severe]'));
+      expect(output, contains('something'));
+    });
+
+    test('export() includes only tag when level is absent', () {
+      final buffer = LogBuffer();
+      final ts = DateTime(2026, 1, 15, 12, 0, 0);
+      buffer.add('tagged msg', tag: 'Network', timestamp: ts);
+      final output = buffer.export();
+      expect(output, contains('Network:'));
+      expect(output, contains('tagged msg'));
+    });
+
+    test('export() plain entries (no level/tag) use original format', () {
+      final buffer = LogBuffer();
+      final ts = DateTime(2026, 3, 28, 10, 30, 0);
+      buffer.add('plain line', timestamp: ts);
+      final output = buffer.export();
+      expect(output, contains('2026-03-28'));
+      expect(output, contains('plain line'));
+      expect(output, isNot(contains('[')));
+    });
+
+    test('export() mixes plain and metadata entries', () {
+      final buffer = LogBuffer();
+      final ts = DateTime(2026, 1, 15, 12, 0, 0);
+      buffer.add('print output', timestamp: ts);
+      buffer.add('logger output', level: 'debug', tag: 'App', timestamp: ts);
+      final output = buffer.export();
+      final lines = output.trim().split('\n');
+      expect(lines.length, 2);
+      expect(lines[0], isNot(contains('[')));
+      expect(lines[1], contains('[debug]'));
+      expect(lines[1], contains('App:'));
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Adds `Critic.instance.captureLog(message, {level, tag, timestamp})` — a public ingestion API so integrators can forward log records from `package:logging`, `package:logger`, `package:talker`, or any logging library into the SDK's `LogBuffer`
- Extends `LogEntry` with optional `level` and `tag` fields; `LogBuffer.add()` and `export()` updated to carry and format them
- Adds `Critic.instance` static getter as a convenient alias for `Critic()`
- No new runtime dependencies — the SDK remains library-agnostic
- Example app wires `package:logging` (dev dependency) into `captureLog` as a working demo
- README updated with wiring patterns for `package:logging`, `package:logger`, and `dart:developer log()`

## Test plan

- [x] `test/log_buffer_test.dart` — 20 tests passing, including 9 new tests for level/tag add and export formatting
- [x] `test/capture_log_test.dart` — 10 new tests: message, level, tag, timestamp, ordering, null defaults, export round-trip, singleton identity, and shared-buffer verification
- [x] `test/log_capture_test.dart` — 13 existing tests unchanged and passing (print() + FlutterError capture still work)
- [x] `fvm flutter analyze` — no issues
- [x] `fvm dart format` — all files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)