### PR TITLE
fix: allowlist mocktail@1.0.5 to pass Nightly Security quarantine check

### DIFF
--- a/.github/quarantine-allowlist.yml
+++ b/.github/quarantine-allowlist.yml
@@ -40,3 +40,7 @@ packages:
     version: "9.0.1"
     reason: "FlutterCommunity plus_plugins coordinated release, verified publisher"
     expires: "2026-04-13"
+  - name: "mocktail"
+    version: "1.0.5"
+    reason: "Patch release by verified publisher felangel; dev-only test mock library with no production impact"
+    expires: "2026-04-17"


### PR DESCRIPTION
## Summary

- `mocktail@1.0.5` was published on 2026-04-10T04:16:05Z, ~2 hours before the 06:00 UTC nightly run
- `pubspec.yaml` declares `mocktail: ^1.0.4`, so `flutter pub get` in CI resolves to the freshly-published `1.0.5`
- This triggered the 7-day quarantine check in the Nightly Security workflow, causing it to fail with exit code 1
- Fix: add a time-bounded allowlist entry for `mocktail@1.0.5` expiring 2026-04-17 (7 days after publish)

## Changes

- `.github/quarantine-allowlist.yml`: Add `mocktail@1.0.5` allowlist entry with reason and expires date of 2026-04-17

## Why This Is Safe

`mocktail` is a dev-only test mock library by verified publisher `felangel` with no production impact. The allowlist entry expires 2026-04-17, after which the package will be 7+ days old and pass the check natively.

## Test Plan

- [ ] Nightly Security workflow package-age-check job passes on this PR branch
- [ ] All previously allowlisted packages (async, connectivity_plus, connectivity_plus_platform_interface, device_info_plus, package_info_plus) remain present and valid
- [ ] YAML parses correctly: `python3 -c "import yaml; yaml.safe_load(open('.github/quarantine-allowlist.yml'))"`

Closes CRITIC-269